### PR TITLE
Updated fix for the buffer overflow bug

### DIFF
--- a/fastlz.c
+++ b/fastlz.c
@@ -112,17 +112,13 @@ static uint64_t flz_readu64(const void* ptr) { return *(const uint64_t*)ptr; }
 static uint32_t flz_cmp(const uint8_t* p, const uint8_t* q, const uint8_t* r) {
   const uint8_t* start = p;
 
-  if (flz_readu64(p) == flz_readu64(q)) {
+  if (flz_readu64(p) == flz_readu64(q) && q + 8 < r) {
     p += 8;
     q += 8;
   }
-  if (flz_readu32(p) == flz_readu32(q)) {
+  if (flz_readu32(p) == flz_readu32(q) && q + 4 < r) {
     p += 4;
     q += 4;
-  }
-  if (q > r) {
-    p = p - (q - r);
-    q = r;
   }
   while (q < r)
     if (*p++ != *q++) break;


### PR DESCRIPTION
Providing a new fix for the buffer overflow bug identified by Morello. It might be easier to decipher what the conditional check is doing compared to a solution, where pointer increments are backtracked.